### PR TITLE
Switch pause and play icons

### DIFF
--- a/preview/src/player/controls.tsx
+++ b/preview/src/player/controls.tsx
@@ -106,7 +106,7 @@ export function Controls(props: {
                 <ControlButton
                     className='playButton'
                     title={props.playing ? "Pause" : "Play"}
-                    icon={props.playing ? 'codicon-play' : 'codicon-pause'}
+                    icon={props.playing ? 'codicon-pause' : 'codicon-play'}
                     onClick={() => {
                         props.updatePlaying(!props.playing);
                     }} />


### PR DESCRIPTION
addresses #2 

It feels counter intuitive to press the 'play' button to pause and the pause button to play the content. 

I didn't test the PR, but the change seems simple enough.